### PR TITLE
Optimize indexing and add batch insert support

### DIFF
--- a/src/hirag_prod/markdown_utils.py
+++ b/src/hirag_prod/markdown_utils.py
@@ -1,13 +1,14 @@
 import os
 import re
 from typing import Optional
-
 from urllib.request import urlopen
 
 IMAGE_PATTERN = re.compile(r"!\[(?P<alt>[^\]]*)\]\((?P<url>[^)]+)\)")
 
 
-def store_markdown_images(markdown: str, image_dir: str, base_url: Optional[str] = None) -> str:
+def store_markdown_images(
+    markdown: str, image_dir: str, base_url: Optional[str] = None
+) -> str:
     """Download images referenced in markdown and update the links.
 
     Parameters
@@ -39,7 +40,9 @@ def store_markdown_images(markdown: str, image_dir: str, base_url: Optional[str]
             data = resp.read()
         with open(local_path, "wb") as f:
             f.write(data)
-        updated_link = f"![{alt}]({os.path.join(os.path.basename(image_dir), filename)})"
+        updated_link = (
+            f"![{alt}]({os.path.join(os.path.basename(image_dir), filename)})"
+        )
         updated = updated.replace(match.group(0), updated_link)
 
     return updated

--- a/tests/test_markdown_utils.py
+++ b/tests/test_markdown_utils.py
@@ -1,7 +1,7 @@
-from pathlib import Path
-from unittest.mock import patch
 import importlib.util
 import sys
+from pathlib import Path
+from unittest.mock import patch
 
 # Load module without executing hirag_prod __init__
 module_path = Path(__file__).resolve().parents[1] / "src/hirag_prod/markdown_utils.py"


### PR DESCRIPTION
## Summary
- allow `LanceDB` to insert embeddings in batches via `upsert_texts`
- use batch inserts in `HiRAG._process_document` to speed up indexing
- test new upsert_texts API
- apply formatting fixes

## Testing
- `bash format.sh src/hirag_prod/storage/lancedb.py src/hirag_prod/hirag.py tests/test_lancedb.py`
- `pytest -q` *(fails: ModuleNotFoundError: No module named 'mcp')*

------
https://chatgpt.com/codex/tasks/task_e_684705f51d0c83339e48a0ba0f3e68c8